### PR TITLE
delete useless code

### DIFF
--- a/cefcon/MAST_script.R
+++ b/cefcon/MAST_script.R
@@ -19,7 +19,6 @@ pseudotime_lineages <- read.csv(paste0(out_dir, '/pseudotime_lineages.csv'), hea
 
 ## MAST
 # MAST assumes that log-transformed approximately scale-normalized data is provided (such as log2(TPM+1))
-split_num <- 4
 for(p in colnames(pseudotime_lineages))
 {
   lin <- pseudotime_lineages[, p]

--- a/cefcon/slingshot_MAST_script.R
+++ b/cefcon/slingshot_MAST_script.R
@@ -35,7 +35,6 @@ write.csv(pseudotime, paste0(out_dir, '/pseudotime_lineages.csv'), quote=FALSE)
 
 ## MAST
 # MAST assumes that log-transformed approximately scale-normalized data is provided (such as log2(TPM+1))
-split_num <- 4
 for(p in colnames(pseudotime))
 {
   lin <- pseudotime[, p]


### PR DESCRIPTION
There is a line of code `split_num<-4` in two R files, which will cause the parameters passed in from the outside to become invalid.